### PR TITLE
Fix page numering and add input checking on Page

### DIFF
--- a/HiperRestApiPack.EF/FilteredQuery.cs
+++ b/HiperRestApiPack.EF/FilteredQuery.cs
@@ -105,6 +105,6 @@ namespace HiperRestApiPack.EF
             return source;
         }
 
-
     }
+
 }

--- a/HiperRestApiPack.Tests/HiperRestApiPack.Tests.csproj
+++ b/HiperRestApiPack.Tests/HiperRestApiPack.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HiperRestApiPack\HiperRestApiPack.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HiperRestApiPack.Tests/PageTests.cs
+++ b/HiperRestApiPack.Tests/PageTests.cs
@@ -1,0 +1,67 @@
+using NUnit.Framework;
+using System;
+
+namespace HiperRestApiPack.Tests
+{
+    public class PageTests
+    {
+        
+        [Test]
+        public void TestIndex()
+        {
+            var page = new Page(null, 1, 10, 100);
+            Assert.AreEqual(100, page.TotalCount);
+            Assert.AreEqual(10, page.TotalPages);
+            Assert.True(page.HasNextPage);
+            Assert.False(page.HasPreviousPage);
+
+            page = new Page(null, 10, 10, 100);
+            Assert.AreEqual(100, page.TotalCount);
+            Assert.AreEqual(10, page.TotalPages);
+            Assert.False(page.HasNextPage);
+            Assert.True(page.HasPreviousPage);
+
+            page = new Page(null, 5, 10, 100);
+            Assert.AreEqual(100, page.TotalCount);
+            Assert.AreEqual(10, page.TotalPages);
+            Assert.True(page.HasNextPage);
+            Assert.True(page.HasPreviousPage);
+
+            page = new Page(null, 1, 1, 1);
+            Assert.AreEqual(1, page.TotalCount);
+            Assert.AreEqual(1, page.TotalPages);
+            Assert.False(page.HasNextPage);
+            Assert.False(page.HasPreviousPage);
+
+            page = new Page(null, 1, 100, 2);
+            Assert.AreEqual(2, page.TotalCount);
+            Assert.AreEqual(1, page.TotalPages);
+            Assert.False(page.HasNextPage);
+            Assert.False(page.HasPreviousPage);
+        }
+
+        [Test]
+        public void TestConstructorChecks() {
+            Assert.Throws<ArgumentOutOfRangeException>(() => {
+                new Page(null, 0, 10, 100);
+            });
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => {
+                new Page(null, 1, 10, -1);
+            });
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => {
+                new Page(null, 11, 10, 100);
+            });
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => {
+                new Page(null, 3, 1, 2);
+            });
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => {
+                new Page(null, 1, -5, 50);
+            });
+        }
+
+    }
+}

--- a/HiperRestApiPack.sln
+++ b/HiperRestApiPack.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HiperRestApiPackSample", "H
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HiperRestApiPack.MySql", "HiperRestApiPack.MySql\HiperRestApiPack.MySql.csproj", "{EEE82E74-884F-4881-8294-AAA4B504CEE7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HiperRestApiPack.Tests", "HiperRestApiPack.Tests\HiperRestApiPack.Tests.csproj", "{11FBFFBB-27D3-4258-9402-F154B51962BF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{EEE82E74-884F-4881-8294-AAA4B504CEE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EEE82E74-884F-4881-8294-AAA4B504CEE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EEE82E74-884F-4881-8294-AAA4B504CEE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11FBFFBB-27D3-4258-9402-F154B51962BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11FBFFBB-27D3-4258-9402-F154B51962BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11FBFFBB-27D3-4258-9402-F154B51962BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11FBFFBB-27D3-4258-9402-F154B51962BF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HiperRestApiPack/IFilteredQuery.cs
+++ b/HiperRestApiPack/IFilteredQuery.cs
@@ -20,6 +20,5 @@ namespace HiperRestApiPack
             Func<TSource, TResult> mapper) where TResult : class, new();
 
         IQueryable<TSource> Order<TSource>(IQueryable<TSource> query, PagedRequest request);
-
     }
 }

--- a/HiperRestApiPack/Paging/Page.cs
+++ b/HiperRestApiPack/Paging/Page.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace HiperRestApiPack
@@ -8,7 +9,9 @@ namespace HiperRestApiPack
         public object Data { get; set; }
 
         public bool Success { get; set; } = true;
+
         public int? ErrorCode { get; set; }
+
         public string Message { get; set; }
     }
 
@@ -27,20 +30,30 @@ namespace HiperRestApiPack
         bool HasPreviousPage { get; }
 
         bool HasNextPage { get; }
-  
     }
 
     public class Page : IPage
     {
         public Page(object items, int pageIndex, int pageSize, int totalItemCount)
         {
-            this.Items = items;
-            this.Index = pageIndex;
-            this.Size = pageSize;
-            this.TotalCount = totalItemCount;
-            this.TotalPages = (totalItemCount / pageSize) + 1;
-            this.HasNextPage = pageIndex < this.TotalPages;
-            this.HasPreviousPage = pageIndex > 1;
+            if(pageSize <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(pageSize));
+            }
+            if(totalItemCount < 0) {
+                throw new ArgumentOutOfRangeException(nameof(totalItemCount));
+            }
+
+            Items = items;
+            Index = pageIndex;
+            Size = pageSize;
+            TotalCount = totalItemCount;
+            TotalPages = (int)Math.Ceiling(totalItemCount / (double)pageSize);
+            HasNextPage = pageIndex < TotalPages;
+            HasPreviousPage = pageIndex > 1;
+
+            if (pageIndex <= 0 || pageIndex > TotalPages) {
+                throw new ArgumentOutOfRangeException(nameof(pageIndex));
+            }
         }
 
         public object Items { get; }
@@ -52,6 +65,5 @@ namespace HiperRestApiPack
         public bool HasNextPage { get; }
 
         public static IPage Empty => new Page(Enumerable.Empty<object>(), 0, 0, 0);
-
     }
 }

--- a/HiperRestApiPack/Paging/PagedRequest.cs
+++ b/HiperRestApiPack/Paging/PagedRequest.cs
@@ -15,6 +15,7 @@ namespace HiperRestApiPack
         /// </summary>
         Desc
     }
+
     public class PagedRequest
     {
         /// <summary>
@@ -34,7 +35,7 @@ namespace HiperRestApiPack
 
         /// <summary>
         /// Size of page to fetch
-        /// Default is 20
+        /// Default is 10
         /// </summary>
         public int PageSize { get; set; } = 10;
 


### PR DESCRIPTION
Fix page numbering (see `HiperRestApiPack/Paging/Page.cs`), which now computes the correct page index based on page size and total count. Previously, `Page` would generate these numbers:

- Page size: _1_
- Page index: _2_
- Total count: _3_
- Page count: **4** (Expected: 3.)

Added unit testing project `HiperRestApiPack.Tests/HiperRestApiPack.Tests.csproj` with simple tests for the `Page` class.