### PR TITLE
Make PagedRequest.Order optional, add conversion to query string

### DIFF
--- a/HiperRestApiPack.Tests/PagedRequestToQueryStringTests.cs
+++ b/HiperRestApiPack.Tests/PagedRequestToQueryStringTests.cs
@@ -1,0 +1,41 @@
+﻿using Xunit;
+
+namespace HiperRestApiPack.Tests
+{
+    public class PagedRequestToQueryStringTests
+    {
+        [Fact]
+        public void Test_Empty_PagedRequest()
+        {
+            var pr = new PagedRequest();
+            Assert.Equal("page=1&pageSize=10", pr.PagingQuery());
+        }
+
+        [Fact]
+        public void Test_Full_PagedRequest()
+        {
+            var pr = new PagedRequest
+            {
+                Select = "(Id, Two, Three)",
+                Sum = "Unused",
+                Page = 10,
+                PageSize = 20,
+                Order = OrderType.Desc,
+                OrderBy = "Order",
+                Search = "Search"
+            };
+            Assert.Equal("select=%28Id%2C%20Two%2C%20Three%29&page=10&pageSize=20&order=Desc&orderBy=Order&search=Search", pr.PagingQuery());
+        }
+
+        [Fact]
+        public void Test_WithoutOrder_PagedRequest()
+        {
+            var pr = new PagedRequest
+            {
+                Select = "string with space",
+                PageSize = 100
+            };
+            Assert.Equal("select=string%20with%20space&page=1&pageSize=100", pr.PagingQuery());
+        }
+    }
+}

--- a/HiperRestApiPack/IFilteredQuery.cs
+++ b/HiperRestApiPack/IFilteredQuery.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/HiperRestApiPack/Paging/PagedRequest.cs
+++ b/HiperRestApiPack/Paging/PagedRequest.cs
@@ -1,19 +1,18 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace HiperRestApiPack
 {
-    public enum OrderType
+    public enum OrderType : int
     {
         /// <summary>
         /// Ascending sort
         /// </summary>
-        Asc,
+        Asc = 0,
 
         /// <summary>
         /// Descending sort
         /// </summary>
-        Desc
+        Desc = 1,
     }
 
     public class PagedRequest
@@ -39,7 +38,7 @@ namespace HiperRestApiPack
         /// </summary>
         public int PageSize { get; set; } = 10;
 
-        public OrderType Order { get; set; } = OrderType.Asc;
+        public OrderType? Order { get; set; }
 
         /// <summary>
         /// Field name to sort   

--- a/HiperRestApiPack/Paging/PagedRequestExtensions.cs
+++ b/HiperRestApiPack/Paging/PagedRequestExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace HiperRestApiPack
+{
+    public static class PagedRequestExtensions
+    {
+        public static string PagingQuery(this PagedRequest request)
+        {
+            var parameters = new List<string>();
+            if(!string.IsNullOrEmpty(request.Select))
+            {
+                parameters.Add(string.Format("select={0}", Uri.EscapeDataString(request.Select)));
+            }
+            parameters.Add(string.Format(CultureInfo.InvariantCulture, "page={0}", request.Page));
+            parameters.Add(string.Format(CultureInfo.InvariantCulture, "pageSize={0}", request.PageSize));
+            if(request.Order.HasValue)
+            {
+                parameters.Add(string.Format("order={0}", request.Order.Value));
+            }
+            if(!string.IsNullOrEmpty(request.OrderBy))
+            {
+                parameters.Add(string.Format("orderBy={0}", Uri.EscapeDataString(request.OrderBy)));
+            }
+            if(!string.IsNullOrEmpty(request.Search))
+            {
+                parameters.Add(string.Format("search={0}", Uri.EscapeDataString(request.Search)));
+            }
+
+            return string.Join('&', parameters);
+        }
+    }
+}


### PR DESCRIPTION
This allows to express `PagedRequest` instances without an explicit order direction (otherwise, the ordering would always default to Ascending, as it is the first value of enum `OrderType`). Services receiving a `PagedRequest` can now opt for a default ordering if no ordering is specified.

The `PagingQuery` extension method converts a `PagedRequest` into a query string compatible with an URI. Tests are added in `HiperRestApiPack.Tests.PagedRequestToQueryStringTests`.

This is a breaking change for users of the library, however. 😬